### PR TITLE
schema registry, accounting, analitics, jira-id

### DIFF
--- a/PopugJira/EventSchemaRegistry/KafkaEvent.cs
+++ b/PopugJira/EventSchemaRegistry/KafkaEvent.cs
@@ -1,0 +1,20 @@
+﻿namespace EventSchemaRegistry;
+
+public class KafkaEvent<T> where T : class
+{
+    public Guid EventId { get; init; } = Guid.NewGuid();
+    public DateTimeOffset SentTime { get; init; } = DateTimeOffset.Now;
+    public int Version { get; init; }
+    public string Producer { get; init; }
+    public string EventName { get; init; }
+    public T Data { get; init; }
+
+    public KafkaEvent(T data, string producer)
+    {
+        Data = data;
+        Producer = producer;
+        EventName = typeof(T).Name;
+        Version = int.Parse(EventName.Split('_').Last().Trim('V'));
+    }
+    
+}

--- a/PopugJira/EventSchemaRegistry/Schemas/FinTransaction/Applied/1.json
+++ b/PopugJira/EventSchemaRegistry/Schemas/FinTransaction/Applied/1.json
@@ -1,0 +1,61 @@
+﻿{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+
+  "title": "FinTransaction.Applied.v1",
+  "description": "json schema for fin transaction applied event (version 1)",
+
+  "definitions": {
+    "event_data": {
+      "type": "object",
+      "properties": {
+        "transactionId": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "credit": {
+          "type": "string"
+        },
+        "debit": {
+          "type": "string"
+        },
+        "popugId": {
+          "type": "string"
+        },
+        "taskId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "taskId",
+        "transactionId",
+        "type",
+        "credit",
+        "debit",
+        "popugId"
+      ]
+    }
+  },
+
+  "type": "object",
+
+  "properties": {
+    "eventId":       { "type": "string" },
+    "version":       { "enum": [1] },
+    "eventName":    { "const": "FinTransaction_Applied_V1" },
+    "sentTime":    { "type": "string" },
+    "producer":      { "type": "string" },
+
+    "data": { "$ref": "#/definitions/event_data" }
+  },
+
+  "required": [
+    "eventId",
+    "version",
+    "eventName",
+    "sentTime",
+    "producer",
+    "data"
+  ]
+}

--- a/PopugJira/EventSchemaRegistry/Schemas/Payment/Completed/1.json
+++ b/PopugJira/EventSchemaRegistry/Schemas/Payment/Completed/1.json
@@ -1,0 +1,49 @@
+﻿{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+
+  "title": "Payment.Completed.v1",
+  "description": "json schema for payment completed event (version 1)",
+
+  "definitions": {
+    "event_data": {
+      "type": "object",
+      "properties": {
+        "transactionId": {
+          "type": "string"
+        },
+        "payment": {
+          "type": "integer"
+        },
+        "popugId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "transactionId",
+        "payment",
+        "popugId"
+      ]
+    }
+  },
+
+  "type": "object",
+
+  "properties": {
+    "eventId":       { "type": "string" },
+    "version":       { "enum": [1] },
+    "eventName":    { "const": "Payment_Completed_V1" },
+    "sentTime":    { "type": "string" },
+    "producer":      { "type": "string" },
+
+    "data": { "$ref": "#/definitions/event_data" }
+  },
+
+  "required": [
+    "eventId",
+    "version",
+    "eventName",
+    "sentTime",
+    "producer",
+    "data"
+  ]
+}

--- a/PopugJira/EventSchemaRegistry/Schemas/Popug/Changed/1.json
+++ b/PopugJira/EventSchemaRegistry/Schemas/Popug/Changed/1.json
@@ -1,0 +1,49 @@
+﻿{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+
+  "title": "Popug.Changed.v1",
+  "description": "json schema for popug changed event (version 1)",
+
+  "definitions": {
+    "event_data": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "changeType": {
+          "enum": ["created"]
+        },
+        "changes": {
+          "type": "object"
+        }
+      },
+      "required": [
+        "id",
+        "changeType",
+        "changes"
+      ]
+    }
+  },
+
+  "type": "object",
+
+  "properties": {
+    "eventId":       { "type": "string" },
+    "version":       { "enum": [1] },
+    "eventName":    { "const": "Popug_Changed_V1" },
+    "sentTime":    { "type": "string" },
+    "producer":      { "type": "string" },
+
+    "data": { "$ref": "#/definitions/event_data" }
+  },
+
+  "required": [
+    "eventId",
+    "version",
+    "eventName",
+    "sentTime",
+    "producer",
+    "data"
+  ]
+}

--- a/PopugJira/EventSchemaRegistry/Schemas/Task/Added/1.json
+++ b/PopugJira/EventSchemaRegistry/Schemas/Task/Added/1.json
@@ -1,0 +1,45 @@
+﻿{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+
+  "title": "Task.Added.v1",
+  "description": "json schema for task added event (version 1)",
+
+  "definitions": {
+    "event_data": {
+      "type": "object",
+      "properties": {
+        "taskId": {
+          "type": "string"
+        },
+        "assignee": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "taskId",
+        "assignee"
+      ]
+    }
+  },
+
+  "type": "object",
+
+  "properties": {
+    "eventId":       { "type": "string" },
+    "version":       { "enum": [1] },
+    "eventName":    { "const": "Task_Changed_V1" },
+    "sentTime":    { "type": "string" },
+    "producer":      { "type": "string" },
+
+    "data": { "$ref": "#/definitions/event_data" }
+  },
+
+  "required": [
+    "eventId",
+    "version",
+    "eventName",
+    "sentTime",
+    "producer",
+    "data"
+  ]
+}

--- a/PopugJira/EventSchemaRegistry/Schemas/Task/Assigned/1.json
+++ b/PopugJira/EventSchemaRegistry/Schemas/Task/Assigned/1.json
@@ -1,0 +1,45 @@
+﻿{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+
+  "title": "Task.Assigned.v1",
+  "description": "json schema for task assigned event (version 1)",
+
+  "definitions": {
+    "event_data": {
+      "type": "object",
+      "properties": {
+        "taskId": {
+          "type": "string"
+        },
+        "assignee": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "taskId",
+        "assignee"
+      ]
+    }
+  },
+
+  "type": "object",
+
+  "properties": {
+    "eventId":       { "type": "string" },
+    "version":       { "enum": [1] },
+    "eventName":    { "const": "Task_Changed_V1" },
+    "sentTime":    { "type": "string" },
+    "producer":      { "type": "string" },
+
+    "data": { "$ref": "#/definitions/event_data" }
+  },
+
+  "required": [
+    "eventId",
+    "version",
+    "eventName",
+    "sentTime",
+    "producer",
+    "data"
+  ]
+}

--- a/PopugJira/EventSchemaRegistry/Schemas/Task/Changed/1.json
+++ b/PopugJira/EventSchemaRegistry/Schemas/Task/Changed/1.json
@@ -1,0 +1,57 @@
+﻿{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+
+  "title": "Task.Changed.v1",
+  "description": "json schema for task changed event (version 1)",
+
+  "definitions": {
+    "event_data": {
+      "type": "object",
+      "properties": {
+        "taskId": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "assignee": {
+          "type": "string"
+        },
+        "status": {
+          "enum": ["active", "completed"]
+        },
+        "changeType": {
+          "enum": ["created"]
+        }
+      },
+      "required": [
+        "taskId",
+        "description",
+        "assignee",
+        "status",
+        "changeType"
+      ]
+    }
+  },
+
+  "type": "object",
+
+  "properties": {
+    "eventId":       { "type": "string" },
+    "version":       { "enum": [1] },
+    "eventName":    { "const": "Task_Changed_V1" },
+    "sentTime":    { "type": "string" },
+    "producer":      { "type": "string" },
+
+    "data": { "$ref": "#/definitions/event_data" }
+  },
+
+  "required": [
+    "eventId",
+    "version",
+    "eventName",
+    "sentTime",
+    "producer",
+    "data"
+  ]
+}

--- a/PopugJira/EventSchemaRegistry/Schemas/Task/Changed/2.json
+++ b/PopugJira/EventSchemaRegistry/Schemas/Task/Changed/2.json
@@ -1,0 +1,61 @@
+﻿{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+
+  "title": "Task.Changed.v2",
+  "description": "json schema for task changed event (version 2)",
+
+  "definitions": {
+    "event_data": {
+      "type": "object",
+      "properties": {
+        "taskId": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string",
+          "pattern": "[^\\]\\[]*"
+        },
+        "assignee": {
+          "type": "string"
+        },
+        "status": {
+          "enum": ["active", "completed"]
+        },
+        "changeType": {
+          "enum": ["created"]
+        },
+        "jiraId": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "taskId",
+        "description",
+        "assignee",
+        "status",
+        "changeType"
+      ]
+    }
+  },
+
+  "type": "object",
+
+  "properties": {
+    "eventId":       { "type": "string" },
+    "version":       { "enum": [1] },
+    "eventName":    { "const": "Task_Changed_V2" },
+    "sentTime":    { "type": "string" },
+    "producer":      { "type": "string" },
+
+    "data": { "$ref": "#/definitions/event_data" }
+  },
+
+  "required": [
+    "eventId",
+    "version",
+    "eventName",
+    "sentTime",
+    "producer",
+    "data"
+  ]
+}

--- a/PopugJira/EventSchemaRegistry/Schemas/Task/Completed/1.json
+++ b/PopugJira/EventSchemaRegistry/Schemas/Task/Completed/1.json
@@ -1,0 +1,45 @@
+﻿{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+
+  "title": "Task.Completed.v1",
+  "description": "json schema for task completed event (version 1)",
+
+  "definitions": {
+    "event_data": {
+      "type": "object",
+      "properties": {
+        "taskId": {
+          "type": "string"
+        },
+        "assignee": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "taskId",
+        "assignee"
+      ]
+    }
+  },
+
+  "type": "object",
+
+  "properties": {
+    "eventId":       { "type": "string" },
+    "version":       { "enum": [1] },
+    "eventName":    { "const": "Task_Changed_V1" },
+    "sentTime":    { "type": "string" },
+    "producer":      { "type": "string" },
+
+    "data": { "$ref": "#/definitions/event_data" }
+  },
+
+  "required": [
+    "eventId",
+    "version",
+    "eventName",
+    "sentTime",
+    "producer",
+    "data"
+  ]
+}

--- a/PopugJira/EventSchemaRegistry/Schemas/TaskPrice/Calculated/1.json
+++ b/PopugJira/EventSchemaRegistry/Schemas/TaskPrice/Calculated/1.json
@@ -1,0 +1,49 @@
+﻿{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+
+  "title": "TaskPrice.Calculated.v1",
+  "description": "json schema for task price calculated event (version 1)",
+
+  "definitions": {
+    "event_data": {
+      "type": "object",
+      "properties": {
+        "taskId": {
+          "type": "string"
+        },
+        "assignPrice": {
+          "type": "integer"
+        },
+        "completePrice": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "taskId",
+        "assignPrice",
+        "completePrice"
+      ]
+    }
+  },
+
+  "type": "object",
+
+  "properties": {
+    "eventId":       { "type": "string" },
+    "version":       { "enum": [1] },
+    "eventName":    { "const": "TaskPrice_Calculated_V1" },
+    "sentTime":    { "type": "string" },
+    "producer":      { "type": "string" },
+
+    "data": { "$ref": "#/definitions/event_data" }
+  },
+
+  "required": [
+    "eventId",
+    "version",
+    "eventName",
+    "sentTime",
+    "producer",
+    "data"
+  ]
+}

--- a/PopugJira/EventSchemaRegistry/SchemeValidator.cs
+++ b/PopugJira/EventSchemaRegistry/SchemeValidator.cs
@@ -1,0 +1,30 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Schema;
+
+namespace EventSchemaRegistry;
+
+public static class SchemeValidator
+{
+    public static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions() {PropertyNamingPolicy = JsonNamingPolicy.CamelCase};
+    public static bool IsValid<T>(KafkaEvent<T> value, out IList<string> errors) where T : class
+    {
+        var eventNameArr = value.EventName.Split('_');
+        var schema = JSchema.Parse(new StreamReader(Assembly.GetExecutingAssembly()
+            .GetManifestResourceStream($"EventSchemaRegistry.Schemas.{eventNameArr[0]}.{eventNameArr[1]}.{value.Version}.json"))
+            .ReadToEnd());
+
+        var result = JObject.Parse(JsonSerializer.Serialize(value, SerializerOptions))
+            .IsValid(schema, out errors);
+        return result;
+    }
+
+    public static void ValidateOrThrow<T>(KafkaEvent<T> value) where T : class
+    {
+        if(!IsValid(value, out var errors))
+            throw new ValidationException(string.Join(',', errors));
+    }
+}

--- a/PopugJira/PopugJira.Accounting.Contracts/BusinessEvents.cs
+++ b/PopugJira/PopugJira.Accounting.Contracts/BusinessEvents.cs
@@ -1,0 +1,5 @@
+﻿namespace PopugJira.Accounting.Contracts;
+
+public record FinTransaction_Applied_V1(Guid TransactionId, string Type, int Credit, int Debit, Guid PopugId, Guid? TaskId);
+
+public record Payment_Completed_V1(Guid TransactionId, int Payment, Guid PopugId);

--- a/PopugJira/PopugJira.Accounting.Contracts/CudEvents.cs
+++ b/PopugJira/PopugJira.Accounting.Contracts/CudEvents.cs
@@ -1,0 +1,3 @@
+﻿namespace PopugJira.Accounting.Contracts;
+
+public record TaskPrice_Calculated_V1(Guid TaskId, int AssignPrice, int CompletePrice);

--- a/PopugJira/PopugJira.Accounting.Contracts/TransactionTypes.cs
+++ b/PopugJira/PopugJira.Accounting.Contracts/TransactionTypes.cs
@@ -1,0 +1,8 @@
+﻿namespace PopugJira.Accounting.Contracts;
+
+public static class TransactionTypes
+{
+    public const string Assign = "assign";
+    public const string Complete = "complete";
+    public const string Payment = "payment";
+}

--- a/PopugJira/PopugJira.Accounting/Controllers/BillingDayController.cs
+++ b/PopugJira/PopugJira.Accounting/Controllers/BillingDayController.cs
@@ -1,0 +1,59 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using PopugJira.Accounting.Contracts;
+using PopugJira.Accounting.Db;
+using PopugJira.Accounting.Models;
+using PopugJira.Accounting.Services;
+using PopugJira.Auth.Contracts;
+
+namespace PopugJira.Accounting.Controllers;
+
+[ApiController]
+[Route("[controller]/[action]")]
+public class BillingDayController : ControllerBase
+{
+    [HttpPost]
+    public async Task FinishDay([FromServices] AccountingDbContext dbContext, [FromServices] EventSender eventSender)
+    {
+        var popugs = await dbContext.Popugs.Where(x => x.Position.Equals(PopugPositionsEnum.Worker)).ToListAsync();
+        var cycle = await dbContext.BillingCycles.FirstOrDefaultAsync(x => x.End == null);
+        if (cycle == null)
+        {
+            cycle = new BillingCycle()
+            {
+                Start = DateTimeOffset.UtcNow
+            };
+            dbContext.BillingCycles.Add(cycle);
+        }
+        foreach (var popug in popugs.Where(x => x.Balance > 0))
+        {
+            var transaction = new Transaction()
+            {
+                PopugId = popug.Id,
+                Credit = popug.Balance,
+                Debit = 0,
+                TransactionType = TransactionTypes.Payment,
+                Date = DateTimeOffset.UtcNow,
+                BillingCycle = cycle.Id
+            };
+            dbContext.Transactions.Add(transaction);
+            
+            //увы, батчей в этой библиотеке нет
+            await eventSender.TransactionApplied(transaction, popug.ReplicationId);
+            await SomePaymentLogic(eventSender, transaction, popug);
+        }
+        cycle.End = DateTimeOffset.UtcNow;
+        var newCycle = new BillingCycle()
+        {
+            Start = DateTimeOffset.UtcNow
+        };
+        dbContext.BillingCycles.Add(newCycle);
+        await dbContext.SaveChangesAsync();
+    }
+
+    private static async Task SomePaymentLogic(EventSender eventSender, Transaction transaction, Popug popug)
+    {
+        popug.Balance = 0;
+        await eventSender.PaymentCompleted(transaction, popug);
+    }
+}

--- a/PopugJira/PopugJira.Accounting/Controllers/PopugViewController.cs
+++ b/PopugJira/PopugJira.Accounting/Controllers/PopugViewController.cs
@@ -1,0 +1,86 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using OpenIddict.Abstractions;
+using PopugJira.Accounting.Contracts;
+using PopugJira.Accounting.Db;
+using PopugJira.Accounting.Models;
+using PopugJira.Accounting.ViewModels;
+
+namespace PopugJira.Accounting.Controllers;
+
+[ApiController]
+[Route("[controller]/[action]")]
+public class PopugViewController : ControllerBase
+{
+    [HttpGet]
+    [Authorize("worker")]
+    public async Task<PopugBalanceViewModel> GetWorkerInfo([FromServices] AccountingDbContext db)
+    {
+        var popugId = Guid.Parse(HttpContext.User.GetClaim(OpenIddictConstants.Claims.Subject) ?? string.Empty);
+        var popug = await db.Popugs.FirstOrDefaultAsync(x => x.ReplicationId == popugId);
+        if (popug == null)
+            return new PopugBalanceViewModel(0, new List<LogRecord>());
+
+        var lastCycles = await db.BillingCycles.AsNoTracking()
+            .OrderByDescending(x => x.Start)
+            .Take(7)
+            .Select(x => x.Id)
+            .ToListAsync();
+        var transactions = await db.Transactions.AsNoTracking()
+            .Where(x => lastCycles.Contains(x.BillingCycle))
+            .ToListAsync();
+        var taskIds = transactions.Where(x => x.TaskId != null).Select(x => x.TaskId);
+        var tasks = await db.Tasks.AsNoTracking()
+            .Where(x => taskIds.Contains(x.Id))
+            .ToDictionaryAsync(x => x.Id, v => v.Description);
+
+
+        return new PopugBalanceViewModel(popug.Balance, transactions.Select(x =>
+            new LogRecord(x.Date, x.Debit - x.Credit,
+                x.TaskId != null
+                    ? tasks[x.TaskId!.Value] ?? ""
+                    : "Выплата заработка"
+            )).ToList());
+    }
+
+    [HttpGet]
+    [Authorize("accountant")]
+    public async Task<TopPopugsViewModel> GetTopsEarnings([FromServices] AccountingDbContext db)
+    {
+        var lastCycles = await db.BillingCycles.AsNoTracking()
+            .OrderByDescending(x => x.Start)
+            .Take(7)
+            .ToListAsync();
+        
+        var transactions = await db.Transactions.AsNoTracking()
+            .Where(x => x.TransactionType != TransactionTypes.Payment)
+            .Where(x => lastCycles.Select(c => c.Id).Contains(x.BillingCycle))
+            .ToListAsync();
+
+        var cycleTrans = transactions.GroupBy(x => x.BillingCycle)
+            .ToDictionary(x => x.Key);
+        var currentCycle = lastCycles.First(x => x.End == null);
+
+        return new TopPopugsViewModel(
+            GetEarning(cycleTrans[currentCycle.Id]), lastCycles
+                .Where(x => x != currentCycle)
+                .Select(x => new PreviousEarn(GetEarning(cycleTrans[x.Id]), x.Start, x.End!.Value))
+                .ToList()
+        );
+
+        int GetEarning(IEnumerable<Transaction> cycleTransactions)
+        {
+            var result = 0;
+            foreach (var trans in cycleTransactions)
+            {
+                if (trans.TransactionType == TransactionTypes.Assign)
+                    result += trans.Credit;
+                if (trans.TransactionType == TransactionTypes.Complete)
+                    result -= trans.Debit;
+            }
+
+            return result;
+        }
+    }
+}

--- a/PopugJira/PopugJira.Accounting/DiExt/KafkaDiExtensions.cs
+++ b/PopugJira/PopugJira.Accounting/DiExt/KafkaDiExtensions.cs
@@ -1,0 +1,54 @@
+﻿using EventSchemaRegistry;
+using MassTransit;
+using PopugJira.Accounting.Contracts;
+using PopugJira.Accounting.Handlers;
+using PopugJira.Auth.Contracts;
+using PopugJira.Tracker.Contracts;
+
+namespace PopugJira.Accounting.DiExt;
+
+public static class KafkaDiExtensions
+{
+    public static void AddKafka(this IServiceCollection services)
+    {
+        services.AddMassTransit(cfg =>
+        {
+            cfg.UsingInMemory();
+            cfg.AddRider(rider =>
+            {
+                rider.AddConsumer<CalcTaskPricesHandler>();
+                rider.AddConsumer<AccountManageHandler>();
+                rider.AddConsumer<ApplyTransactionHandler>();
+
+                rider.AddProducer<KafkaEvent<TaskPrice_Calculated_V1>>("taskPrices-streaming.v1");
+                rider.AddProducer<KafkaEvent<FinTransaction_Applied_V1>>("fin-transactions.applied.v1");
+                rider.AddProducer<KafkaEvent<Payment_Completed_V1>>("payments.completed.v1");
+                
+                rider.UsingKafka(((context, kafka) =>
+                {
+                    kafka.Host("localhost:9092");
+                    kafka.TopicEndpoint<KafkaEvent<Task_Changed_V1>>("tasks-streaming", "accounting", e =>
+                    {
+                        e.ConfigureConsumer<CalcTaskPricesHandler>(context);
+                    });
+                    kafka.TopicEndpoint<KafkaEvent<Popug_Changed_V1>>("popug-streaming", "accounting", e =>
+                    {
+                        e.ConfigureConsumer<AccountManageHandler>(context);
+                    });
+                    kafka.TopicEndpoint<KafkaEvent<Task_Added_V1>>("tasks-lifecycle.added.v1", "accounting", e =>
+                    {
+                        e.ConfigureConsumer<ApplyTransactionHandler>(context);
+                    });
+                    kafka.TopicEndpoint<KafkaEvent<Task_Assigned_V1>>("tasks-lifecycle.assigned.v1", "accounting", e =>
+                    {
+                        e.ConfigureConsumer<ApplyTransactionHandler>(context);
+                    });
+                    kafka.TopicEndpoint<KafkaEvent<Task_Completed_V1>>("tasks-lifecycle.completed.v1", "accounting", e =>
+                    {
+                        e.ConfigureConsumer<ApplyTransactionHandler>(context);
+                    });
+                }));
+            });
+        });
+    }
+}

--- a/PopugJira/PopugJira.Accounting/Handlers/AccountManageHandler.cs
+++ b/PopugJira/PopugJira.Accounting/Handlers/AccountManageHandler.cs
@@ -1,0 +1,32 @@
+﻿using Confluent.Kafka;
+using EventSchemaRegistry;
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using PopugJira.Accounting.Db;
+using PopugJira.Accounting.Models;
+using PopugJira.Auth.Contracts;
+
+namespace PopugJira.Accounting.Handlers;
+
+public class AccountManageHandler(AccountingDbContext db) : IConsumer<KafkaEvent<Popug_Changed_V1>>
+{
+    public async Task Consume(ConsumeContext<KafkaEvent<Popug_Changed_V1>> context)
+    {
+        if(!SchemeValidator.IsValid(context.Message, out var errors))
+            Console.WriteLine(string.Join(',',errors));
+        var message = context.Message.Data;
+        if (message.ChangeType != PopugChangedTypes.Created)
+            return;
+        
+        if(await db.Popugs.AsNoTracking().AnyAsync(x => x.ReplicationId == message.Id))
+            return;
+
+        db.Popugs.Add(new Popug()
+        {
+            ReplicationId = message.Id,
+            Position = message.Changes["Position"]
+        });
+
+        await db.SaveChangesAsync();
+    }
+}

--- a/PopugJira/PopugJira.Accounting/Handlers/ApplyTransactionHandler.cs
+++ b/PopugJira/PopugJira.Accounting/Handlers/ApplyTransactionHandler.cs
@@ -1,0 +1,153 @@
+﻿using Confluent.Kafka;
+using EventSchemaRegistry;
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+using PopugJira.Accounting.Contracts;
+using PopugJira.Accounting.Db;
+using PopugJira.Accounting.Models;
+using PopugJira.Accounting.Services;
+using PopugJira.Auth.Contracts;
+using PopugJira.Tracker.Contracts;
+
+namespace PopugJira.Accounting.Handlers;
+
+public class ApplyTransactionHandler(AccountingDbContext dbContext, EventSender eventSender) : 
+    IConsumer<KafkaEvent<Task_Added_V1>>, 
+    IConsumer<KafkaEvent<Task_Assigned_V1>>,
+    IConsumer<KafkaEvent<Task_Completed_V1>>
+{
+    public async Task Consume(ConsumeContext<KafkaEvent<Task_Added_V1>> context)
+    {
+        try
+        {
+            if(!SchemeValidator.IsValid(context.Message, out var errors))
+                throw new Exception($"Invalid scheme: {string.Join(',',errors)}");
+
+            await ApplyAssign(context.Message.Data.TaskId, context.Message.Data.Assignee, context.Message.SentTime);
+        }
+        catch (Exception e)
+        {
+            await HandleError(context.Message, e);
+        }
+    }
+
+    public async Task Consume(ConsumeContext<KafkaEvent<Task_Assigned_V1>> context)
+    {
+        try
+        {
+            if(!SchemeValidator.IsValid(context.Message, out var errors))
+                throw new Exception($"Invalid scheme: {string.Join(',',errors)}");
+            
+            await ApplyAssign(context.Message.Data.TaskId, context.Message.Data.Assignee, context.Message.SentTime);
+        }
+        catch (Exception e)
+        {
+            await HandleError(context.Message, e);
+        }
+    }
+
+    public async Task Consume(ConsumeContext<KafkaEvent<Task_Completed_V1>> context)
+    {
+        try
+        {
+            if(!SchemeValidator.IsValid(context.Message, out var errors))
+                throw new Exception($"Invalid scheme: {string.Join(',',errors)}");
+            
+            await ApplyComplete(context.Message.Data.TaskId, context.Message.Data.Assignee, context.Message.SentTime);
+        }
+        catch (Exception e)
+        {
+            await HandleError(context.Message, e);
+        }
+    }
+
+    private async Task ApplyAssign(Guid taskId, Guid assignee, DateTimeOffset eventTime)
+    {
+        var (popug, task, cycle) = await GetAggregates(taskId, assignee);
+
+        var transaction = new Transaction()
+        {
+            PopugId = popug.Id,
+            TaskId = task.Id,
+            TransactionType = TransactionTypes.Assign,
+            Credit = task.AssignPrice,
+            Debit = 0,
+            Date = eventTime.ToUniversalTime(),
+            BillingCycle = cycle.Id
+        };
+        popug.Balance -= task.AssignPrice;
+        dbContext.Transactions.Add(transaction);
+        await dbContext.SaveChangesAsync();
+        await eventSender.TransactionApplied(transaction, popug.ReplicationId, task);
+    }
+    
+    private async Task ApplyComplete(Guid taskId, Guid assignee, DateTimeOffset eventTime)
+    {
+        var (popug, task, cycle) = await GetAggregates(taskId, assignee);
+
+        var transaction = new Transaction()
+        {
+            PopugId = popug.Id,
+            TaskId = task.Id,
+            TransactionType = TransactionTypes.Complete,
+            Credit = 0,
+            Debit = task.CompletePrice,
+            Date = eventTime.ToUniversalTime(),
+            BillingCycle = cycle.Id
+        };
+        popug.Balance += task.CompletePrice;
+        
+        dbContext.Transactions.Add(transaction);
+        await dbContext.SaveChangesAsync();
+        await eventSender.TransactionApplied(transaction, popug.ReplicationId, task);
+    }
+
+    private async Task<(Popug popug, PopugTask task, BillingCycle billingCycle)> GetAggregates(Guid taskId, Guid assignee)
+    {
+        var popug = await dbContext.Popugs.FirstOrDefaultAsync(x => x.ReplicationId == assignee);
+        if (popug == null)
+        {
+            popug = new Popug()
+            {
+                ReplicationId = assignee,
+                Position = PopugPositionsEnum.Worker
+            };
+            dbContext.Popugs.Add(popug);
+        }
+
+        var task = await dbContext.Tasks.FirstOrDefaultAsync(x => x.ReplicationId == taskId);
+        if (task == null)
+        {
+            var (assign, complete) = PriceCalculator.Calc();
+            task = new PopugTask()
+            {
+                ReplicationId = taskId,
+                AssignPrice = assign,
+                CompletePrice = complete
+            };
+            dbContext.Tasks.Add(task);
+        }
+
+        var billingCycle = await dbContext.BillingCycles.FirstOrDefaultAsync(x => x.End == null);
+        if (billingCycle == null)
+        {
+            billingCycle = new BillingCycle()
+            {
+                Start = DateTimeOffset.UtcNow
+            };
+            dbContext.BillingCycles.Add(billingCycle);
+        }
+
+        return (popug, task, billingCycle);
+    }
+    private async Task HandleError(object message, Exception e)
+    {
+        dbContext.HandleErrors.Add(new HandleError()
+        {
+            Message = JsonConvert.SerializeObject(message),
+            Error = e.Message
+        });
+        await dbContext.SaveChangesAsync();
+    }
+}

--- a/PopugJira/PopugJira.Accounting/Handlers/CalcTaskPricesHandler.cs
+++ b/PopugJira/PopugJira.Accounting/Handlers/CalcTaskPricesHandler.cs
@@ -1,0 +1,44 @@
+﻿using EventSchemaRegistry;
+using MassTransit;
+using Newtonsoft.Json;
+using PopugJira.Accounting.Db;
+using PopugJira.Accounting.Models;
+using PopugJira.Accounting.Services;
+using PopugJira.Tracker.Contracts;
+
+namespace PopugJira.Accounting.Handlers;
+
+public class CalcTaskPricesHandler(AccountingDbContext dbContext, EventSender eventSender) : IConsumer<KafkaEvent<Task_Changed_V1>>
+{
+    public async Task Consume(ConsumeContext<KafkaEvent<Task_Changed_V1>> context)
+    {
+        try
+        {
+            var message = context.Message;
+            if(!SchemeValidator.IsValid(message, out var errors))
+               throw new Exception($"Invalid scheme: {string.Join(',',errors)}");
+            
+            var (assign, complete) = PriceCalculator.Calc();
+            var task = new PopugTask()
+            {
+                ReplicationId = message.Data.TaskId,
+                Description = message.Data.Description,
+                AssignPrice = assign,
+                CompletePrice = complete
+            };
+            dbContext.Tasks.Add(task);
+            await dbContext.SaveChangesAsync();
+            await eventSender.PriceCalculated(task);
+        }
+        catch (Exception e)
+        {
+            dbContext.HandleErrors.Add(new HandleError()
+            {
+                Message = JsonConvert.SerializeObject(context.Message),
+                Error = e.Message
+            });
+            await dbContext.SaveChangesAsync();
+        }
+    }
+
+}

--- a/PopugJira/PopugJira.Accounting/Models/BillingCycle.cs
+++ b/PopugJira/PopugJira.Accounting/Models/BillingCycle.cs
@@ -1,0 +1,8 @@
+﻿namespace PopugJira.Accounting.Models;
+
+public class BillingCycle
+{
+    public int Id { get; set; }
+    public DateTimeOffset Start { get; set; }
+    public DateTimeOffset? End { get; set; }
+}

--- a/PopugJira/PopugJira.Accounting/Models/HandleError.cs
+++ b/PopugJira/PopugJira.Accounting/Models/HandleError.cs
@@ -1,0 +1,11 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace PopugJira.Accounting.Models;
+
+public class HandleError
+{
+    [Key]
+    public int Id { get; set; }
+    public required string Message { get; set; }
+    public required string Error { get; set; }
+}

--- a/PopugJira/PopugJira.Accounting/Models/Popug.cs
+++ b/PopugJira/PopugJira.Accounting/Models/Popug.cs
@@ -1,0 +1,12 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace PopugJira.Accounting.Models;
+
+public class Popug
+{
+    [Key]
+    public int Id { get; set; }
+    public required Guid ReplicationId { get; init; }
+    public required string Position { get; set; }
+    public int Balance { get; set; } = 0;
+}

--- a/PopugJira/PopugJira.Accounting/Models/PopugTask.cs
+++ b/PopugJira/PopugJira.Accounting/Models/PopugTask.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace PopugJira.Accounting.Models;
+
+public class PopugTask
+{
+    [Key]
+    public int Id { get; set; }
+    public Guid ReplicationId { get; set; }
+    public string? Description { get; set; }
+    public int AssignPrice { get; set; }
+    public int CompletePrice { get; set; }
+}

--- a/PopugJira/PopugJira.Accounting/Models/Transaction.cs
+++ b/PopugJira/PopugJira.Accounting/Models/Transaction.cs
@@ -1,0 +1,17 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace PopugJira.Accounting.Models;
+
+public class Transaction
+{
+    [Key]
+    public int Id { get; set; }
+    public Guid PublicId { get; set; } = Guid.NewGuid();
+    public int PopugId { get; set; }
+    public int? TaskId { get; set; }
+    public required string TransactionType { get; set; }
+    public int Credit { get; set; }
+    public int Debit { get; set; }
+    public DateTimeOffset Date { get; set; }
+    public required int BillingCycle { get; set; }
+}

--- a/PopugJira/PopugJira.Accounting/Services/EventSender.cs
+++ b/PopugJira/PopugJira.Accounting/Services/EventSender.cs
@@ -1,0 +1,41 @@
+﻿using EventSchemaRegistry;
+using MassTransit;
+using PopugJira.Accounting.Contracts;
+using PopugJira.Accounting.Models;
+
+namespace PopugJira.Accounting.Services;
+
+public class EventSender(ITopicProducer<KafkaEvent<FinTransaction_Applied_V1>> transAppliedProducer,
+    ITopicProducer<KafkaEvent<Payment_Completed_V1>> paymentProducer,
+    ITopicProducer<KafkaEvent<TaskPrice_Calculated_V1>> priceProducer)
+{
+    private const string Producer = "accounting";
+    
+    public async Task PriceCalculated(PopugTask task)
+    {
+        var message = new KafkaEvent<TaskPrice_Calculated_V1>(
+            new TaskPrice_Calculated_V1(task.ReplicationId, task.AssignPrice, task.CompletePrice), Producer);
+        
+        SchemeValidator.ValidateOrThrow(message);
+        await priceProducer.Produce(message);
+    }
+
+    public async Task TransactionApplied(Transaction transaction, Guid popugId, PopugTask? task = null)
+    {
+        var message = new KafkaEvent<FinTransaction_Applied_V1>(
+            new FinTransaction_Applied_V1(transaction.PublicId, transaction.TransactionType, transaction.Credit,
+                transaction.Debit, popugId, task?.ReplicationId),
+            Producer);
+        SchemeValidator.ValidateOrThrow(message);
+        await transAppliedProducer.Produce(message);
+    }
+
+    public async Task PaymentCompleted(Transaction transaction, Popug popug)
+    {
+        var message = new KafkaEvent<Payment_Completed_V1>(
+            new Payment_Completed_V1(transaction.PublicId, transaction.Credit, popug.ReplicationId),
+            Producer);
+        SchemeValidator.ValidateOrThrow(message);
+        await paymentProducer.Produce(message);
+    }
+}

--- a/PopugJira/PopugJira.Accounting/Services/PriceCalculator.cs
+++ b/PopugJira/PopugJira.Accounting/Services/PriceCalculator.cs
@@ -1,0 +1,7 @@
+﻿namespace PopugJira.Accounting.Services;
+
+public static class PriceCalculator
+{
+    public static (int assign, int complete) Calc()
+        => (Random.Shared.Next(10, 20), Random.Shared.Next(20, 40));
+}

--- a/PopugJira/PopugJira.Accounting/ViewModels/LogRecord.cs
+++ b/PopugJira/PopugJira.Accounting/ViewModels/LogRecord.cs
@@ -1,0 +1,3 @@
+﻿namespace PopugJira.Accounting.ViewModels;
+
+public record LogRecord(DateTimeOffset Date, int Change, string Description);

--- a/PopugJira/PopugJira.Accounting/ViewModels/PopugBalanceViewModel.cs
+++ b/PopugJira/PopugJira.Accounting/ViewModels/PopugBalanceViewModel.cs
@@ -1,0 +1,3 @@
+﻿namespace PopugJira.Accounting.ViewModels;
+
+public record PopugBalanceViewModel(int Balance, List<LogRecord> Logs);

--- a/PopugJira/PopugJira.Accounting/ViewModels/TopPopugsViewModel.cs
+++ b/PopugJira/PopugJira.Accounting/ViewModels/TopPopugsViewModel.cs
@@ -1,0 +1,4 @@
+﻿namespace PopugJira.Accounting.ViewModels;
+
+public record TopPopugsViewModel(int Today, List<PreviousEarn> PreviousEarns);
+public record PreviousEarn(int Earned, DateTimeOffset From, DateTimeOffset To);

--- a/PopugJira/PopugJira.Analytics/Controllers/DashboardController.cs
+++ b/PopugJira/PopugJira.Analytics/Controllers/DashboardController.cs
@@ -1,0 +1,77 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using PopugJira.Analytics.Db;
+using PopugJira.Analytics.Models;
+using PopugJira.Analytics.ViewModels;
+
+namespace PopugJira.Analytics.Controllers;
+
+[Route("[controller]/[action]")]
+[ApiController]
+[Authorize("admin")]
+public class DashboardController : ControllerBase
+{
+    [HttpGet]
+    public async Task<MostExpensiveTasksView> MostExpensive([FromServices] AnalyticsDbContext db)
+    {
+        var lastMonthTasks = await db.PopugTasks.AsNoTracking()
+            .Where(x => x.CompleteDate != null && x.CompleteDate.Value.Date >= DateTimeOffset.UtcNow.AddMonths(-1).Date)
+            .OrderBy(x => x.CompleteDate)
+            .ToListAsync();
+
+        return new MostExpensiveTasksView(
+            GetMostExpensive(lastMonthTasks.Where(x => x.CompleteDate?.Date == DateTimeOffset.UtcNow)),
+            GetMostExpensive(lastMonthTasks.Where(x => x.CompleteDate?.Date >= DateTimeOffset.UtcNow.AddDays(7).Date)),
+            GetMostExpensive(lastMonthTasks)
+        );
+        
+        static MostExpensiveTask? GetMostExpensive(IEnumerable<PopugTask> tasks)
+        {
+            var task = tasks.MaxBy(x => x.CompletePrice);
+            return task == null 
+                ? null 
+                : new MostExpensiveTask(task.CompletePrice, task.Description ?? "");
+        }
+    }
+
+    [HttpGet]
+    public async Task<int> TopsEarnings([FromServices] AnalyticsDbContext db)
+    {
+        var todayChanges = await db.TopsBalanceChanges.AsNoTracking()
+            .Where(x => x.Date.Date == DateTimeOffset.UtcNow.Date)
+            .ToListAsync();
+
+        return todayChanges.Sum(change => change.Debit - change.Credit);
+    }
+    
+    [HttpGet]
+    public async Task<int> MinusPopugs([FromServices] AnalyticsDbContext db)
+    {
+        var popugIds = await db.PopugBalanceChanges.AsNoTracking()
+            .Select(x => x.PopugId)
+            .Distinct()
+            .ToListAsync();
+        
+        var count = 0;
+        foreach (var popugId in popugIds)
+        {
+            var lastZero = await db.PopugBalanceChanges.AsNoTracking()
+                .Where(x => x.PopugId == popugId)
+                .OrderByDescending(x => x.Date)
+                .FirstOrDefaultAsync(x => x.ZeroBalance);
+            
+            var todayChanges = await db.PopugBalanceChanges.AsNoTracking()
+                .Where(x => x.PopugId == popugId)
+                .Where(x => lastZero == null || x.Date >= lastZero.Date)
+                .ToListAsync();
+            
+            var result = todayChanges.Sum(change => change.Debit - change.Credit);
+
+            if (result < 0)
+                count++;
+        }
+
+        return count;
+    }
+}

--- a/PopugJira/PopugJira.Analytics/DiExt/KafkaDiExtensions.cs
+++ b/PopugJira/PopugJira.Analytics/DiExt/KafkaDiExtensions.cs
@@ -1,0 +1,40 @@
+﻿using EventSchemaRegistry;
+using MassTransit;
+using PopugJira.Accounting.Contracts;
+using PopugJira.Analytics.Handlers;
+using PopugJira.Tracker.Contracts;
+
+namespace PopugJira.Analytics.DiExt;
+
+public static class KafkaDiExtensions
+{
+    public static void AddKafka(this IServiceCollection services)
+    {
+        services.AddMassTransit(cfg =>
+        {
+            cfg.UsingInMemory();
+            cfg.AddRider(rider =>
+            {
+                rider.AddConsumer<ReplicateTaskHandler>();
+                rider.AddConsumer<StoreTransactionsHandler>();
+                
+                rider.UsingKafka(((context, kafka) =>
+                {
+                    kafka.Host("localhost:9092");
+                    kafka.TopicEndpoint<KafkaEvent<Task_Changed_V1>>("tasks-streaming", "analytics", e =>
+                    {
+                        e.ConfigureConsumer<ReplicateTaskHandler>(context);
+                    });
+                    kafka.TopicEndpoint<KafkaEvent<TaskPrice_Calculated_V1>>("taskPrices-streaming.v1", "analytics", e =>
+                    {
+                        e.ConfigureConsumer<ReplicateTaskHandler>(context);
+                    });
+                    kafka.TopicEndpoint<KafkaEvent<FinTransaction_Applied_V1>>("fin-transactions.applied.v1", "analytics", e =>
+                    {
+                        e.ConfigureConsumer<StoreTransactionsHandler>(context);
+                    });
+                }));
+            });
+        });
+    }
+}

--- a/PopugJira/PopugJira.Analytics/Handlers/ReplicateTaskHandler.cs
+++ b/PopugJira/PopugJira.Analytics/Handlers/ReplicateTaskHandler.cs
@@ -1,0 +1,51 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Confluent.Kafka;
+using EventSchemaRegistry;
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using PopugJira.Accounting.Contracts;
+using PopugJira.Analytics.Db;
+using PopugJira.Analytics.Models;
+using PopugJira.Tracker.Contracts;
+
+namespace PopugJira.Analytics.Handlers;
+
+public class ReplicateTaskHandler(AnalyticsDbContext db) : 
+    IConsumer<KafkaEvent<Task_Changed_V1>>,
+    IConsumer<KafkaEvent<TaskPrice_Calculated_V1>>
+{
+    public async Task Consume(ConsumeContext<KafkaEvent<Task_Changed_V1>> context)
+    {
+        SchemeValidator.ValidateOrThrow(context.Message);
+
+        var task = await GetTask(context.Message.Data.TaskId);
+
+        task.Description = context.Message.Data.Description;
+        await db.SaveChangesAsync();
+    }
+
+    public async Task Consume(ConsumeContext<KafkaEvent<TaskPrice_Calculated_V1>> context)
+    {
+        SchemeValidator.ValidateOrThrow(context.Message);
+        
+        var task = await GetTask(context.Message.Data.TaskId);
+        task.AssignPrice = context.Message.Data.AssignPrice;
+        task.CompletePrice = context.Message.Data.CompletePrice;
+        await db.SaveChangesAsync();
+    }
+
+    private async Task<PopugTask> GetTask(Guid taskId)
+    {
+        var task = await db.PopugTasks.FirstOrDefaultAsync(x => x.ReplicationId == taskId);
+        if (task == null)
+        {
+            task = new PopugTask()
+            {
+                ReplicationId = taskId
+            };
+            db.PopugTasks.Add(task);
+        }
+
+        return task;
+    }
+}

--- a/PopugJira/PopugJira.Analytics/Handlers/StoreTransactionsHandler.cs
+++ b/PopugJira/PopugJira.Analytics/Handlers/StoreTransactionsHandler.cs
@@ -1,0 +1,65 @@
+﻿using Confluent.Kafka;
+using EventSchemaRegistry;
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using PopugJira.Accounting.Contracts;
+using PopugJira.Analytics.Db;
+using PopugJira.Analytics.Models;
+
+namespace PopugJira.Analytics.Handlers;
+
+public class StoreTransactionsHandler(AnalyticsDbContext db) : IConsumer<KafkaEvent<FinTransaction_Applied_V1>>
+{
+    public async Task Consume(ConsumeContext<KafkaEvent<FinTransaction_Applied_V1>> context)
+    {
+        SchemeValidator.ValidateOrThrow(context.Message);
+
+        var task = await db.PopugTasks.AsNoTracking()
+            .FirstAsync(x => x.ReplicationId == context.Message.Data.TaskId);
+        switch (context.Message.Data.Type)
+        {
+            case TransactionTypes.Assign:
+                db.TopsBalanceChanges.Add(new TopsBalanceChange()
+                {
+                    Debit = task.AssignPrice,
+                    Credit = 0,
+                    Date = context.Message.SentTime
+                });
+                db.PopugBalanceChanges.Add(new PopugBalanceChange()
+                {
+                    Date = context.Message.SentTime,
+                    PopugId = context.Message.Data.PopugId,
+                    Credit = task.AssignPrice,
+                    Debit = 0
+                });
+                break;
+            case TransactionTypes.Complete:
+                db.TopsBalanceChanges.Add(new TopsBalanceChange()
+                {
+                    Debit = 0,
+                    Credit = task.CompletePrice,
+                    Date = context.Message.SentTime
+                });
+                db.PopugBalanceChanges.Add(new PopugBalanceChange()
+                {
+                    Date = context.Message.SentTime,
+                    PopugId = context.Message.Data.PopugId,
+                    Credit = 0,
+                    Debit = task.CompletePrice
+                });
+                break;
+            case TransactionTypes.Payment:
+                db.PopugBalanceChanges.Add(new PopugBalanceChange()
+                {
+                    Date = context.Message.SentTime,
+                    PopugId = context.Message.Data.PopugId,
+                    Credit = context.Message.Data.Credit,
+                    Debit = 0,
+                    ZeroBalance = true
+                });
+                break;
+        }
+
+        await db.SaveChangesAsync();
+    }
+}

--- a/PopugJira/PopugJira.Analytics/Models/PopugBalanceChange.cs
+++ b/PopugJira/PopugJira.Analytics/Models/PopugBalanceChange.cs
@@ -1,0 +1,14 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace PopugJira.Analytics.Models;
+
+public class PopugBalanceChange
+{
+    [Key]
+    public int Id { get; set; }
+    public Guid PopugId { get; set; }
+    public int Debit { get; set; }
+    public int Credit { get; set; }
+    public DateTimeOffset Date { get; set; }
+    public bool ZeroBalance { get; set; } = false;
+}

--- a/PopugJira/PopugJira.Analytics/Models/PopugTask.cs
+++ b/PopugJira/PopugJira.Analytics/Models/PopugTask.cs
@@ -1,0 +1,14 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace PopugJira.Analytics.Models;
+
+public class PopugTask
+{
+    [Key]
+    public int Id { get; set; }
+    public Guid ReplicationId { get; set; }
+    public string? Description { get; set; }
+    public int AssignPrice { get; set; }
+    public int CompletePrice { get; set; }
+    public DateTimeOffset? CompleteDate { get; set; }
+}

--- a/PopugJira/PopugJira.Analytics/Models/TopsBalanceChange.cs
+++ b/PopugJira/PopugJira.Analytics/Models/TopsBalanceChange.cs
@@ -1,0 +1,12 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace PopugJira.Analytics.Models;
+
+public class TopsBalanceChange
+{
+    [Key]
+    public int Id { get; set; }
+    public DateTimeOffset Date { get; set; }
+    public int Debit { get; set; }
+    public int Credit { get; set; }
+}

--- a/PopugJira/PopugJira.Analytics/ViewModels/MostExpensiveTasksView.cs
+++ b/PopugJira/PopugJira.Analytics/ViewModels/MostExpensiveTasksView.cs
@@ -1,0 +1,4 @@
+﻿namespace PopugJira.Analytics.ViewModels;
+
+public record MostExpensiveTasksView(MostExpensiveTask? ForDate, MostExpensiveTask? ForWeek, MostExpensiveTask? ForMonth);
+public record MostExpensiveTask(int Price, string Description);

--- a/PopugJira/PopugJira.Auth.Contracts/CudEvents.cs
+++ b/PopugJira/PopugJira.Auth.Contracts/CudEvents.cs
@@ -1,9 +1,10 @@
 ﻿using System.Collections.Immutable;
+using EventSchemaRegistry;
 
 namespace PopugJira.Auth.Contracts;
 
 //CUD
-public record PopugChanged(Guid Id, string ChangeType, Dictionary<string, string> Changes);
+public record Popug_Changed_V1(Guid Id, string ChangeType, Dictionary<string, string> Changes);
 
 public static class PopugChangedTypes
 {

--- a/PopugJira/PopugJira.Tracker.Contracts/BusinessEvents.cs
+++ b/PopugJira/PopugJira.Tracker.Contracts/BusinessEvents.cs
@@ -1,10 +1,5 @@
 ﻿namespace PopugJira.Tracker.Contracts;
 
-public record TaskOperationPerformed(Guid Id, string ChangeType, Guid Assignee);
-
-public static class TaskOperationTypes
-{
-    public const string AddedNew = "added";
-    public const string Assigned = "assigned";
-    public const string Completed = "completed";
-}
+public record Task_Added_V1(Guid TaskId, Guid Assignee);
+public record Task_Assigned_V1(Guid TaskId, Guid Assignee);
+public record Task_Completed_V1(Guid TaskId, Guid Assignee);

--- a/PopugJira/PopugJira.Tracker.Contracts/CudEvents.cs
+++ b/PopugJira/PopugJira.Tracker.Contracts/CudEvents.cs
@@ -1,6 +1,7 @@
 ﻿namespace PopugJira.Tracker.Contracts;
 
-public record TaskChanged(Guid TaskId, string Description, Guid Assignee, string Status, string ChangeType);
+public record Task_Changed_V1(Guid TaskId, string Description, Guid Assignee, string Status, string ChangeType);
+public record Task_Changed_V2(Guid TaskId, string Description, string? JiraId, Guid Assignee, string Status, string ChangeType);
 
 public static class TaskChangedTypes
 {

--- a/PopugJira/PopugJira.Tracker/Controllers/TasksController.cs
+++ b/PopugJira/PopugJira.Tracker/Controllers/TasksController.cs
@@ -27,6 +27,7 @@ public class TasksController : ControllerBase
             Id = Guid.NewGuid(),
             Assignee = await assigner.GetAssignee(),
             Description = request.Description,
+            JiraId = request.JiraId,
             Status = PopugTaskStatus.Active
         };
 

--- a/PopugJira/PopugJira.Tracker/DiExt/KafkaDiExtensions.cs
+++ b/PopugJira/PopugJira.Tracker/DiExt/KafkaDiExtensions.cs
@@ -1,5 +1,7 @@
-﻿using MassTransit;
+﻿using EventSchemaRegistry;
+using MassTransit;
 using MassTransit.KafkaIntegration.Serializers;
+using MassTransit.Serialization;
 using PopugJira.Auth.Contracts;
 using PopugJira.Tracker.Contracts;
 using PopugJira.Tracker.Handlers;
@@ -16,12 +18,15 @@ public static class KafkaDiExtensions
             cfg.AddRider(rider =>
             {
                 rider.AddConsumer<ManageAccountHandler>();
-                rider.AddProducer<TaskChanged>("tasks-streaming");
-                rider.AddProducer<TaskOperationPerformed>("tasks-lifecycle");
+                rider.AddProducer<KafkaEvent<Task_Changed_V1>>("tasks-streaming");
+                rider.AddProducer<KafkaEvent<Task_Changed_V1>>("tasks-streaming.v2");
+                rider.AddProducer<KafkaEvent<Task_Added_V1>>("tasks-lifecycle.added.v1");
+                rider.AddProducer<KafkaEvent<Task_Assigned_V1>>("tasks-lifecycle.assigned.v1");
+                rider.AddProducer<KafkaEvent<Task_Completed_V1>>("tasks-lifecycle.completed.v1");
                 rider.UsingKafka(((context, kafka) =>
                 {
                     kafka.Host("localhost:9092");
-                    kafka.TopicEndpoint<PopugChanged>("popug-streaming", "tracker", e =>
+                    kafka.TopicEndpoint<KafkaEvent<Popug_Changed_V1>>("popug-streaming", "tracker", e =>
                     {
                         e.ConfigureConsumer<ManageAccountHandler>(context);
                     });

--- a/PopugJira/PopugJira.Tracker/Handlers/ManageAccountHandler.cs
+++ b/PopugJira/PopugJira.Tracker/Handlers/ManageAccountHandler.cs
@@ -1,4 +1,5 @@
-﻿using MassTransit;
+﻿using EventSchemaRegistry;
+using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using PopugJira.Auth.Contracts;
 using PopugJira.Tracker.Db;
@@ -6,11 +7,13 @@ using PopugJira.Tracker.Models;
 
 namespace PopugJira.Tracker.Handlers;
 
-public class ManageAccountHandler(TrackerDbContext db) : IConsumer<PopugChanged>
+public class ManageAccountHandler(TrackerDbContext db) : IConsumer<KafkaEvent<Popug_Changed_V1>>
 {
-    public async Task Consume(ConsumeContext<PopugChanged> context)
+    public async Task Consume(ConsumeContext<KafkaEvent<Popug_Changed_V1>> context)
     {
-        var message = context.Message;
+        SchemeValidator.ValidateOrThrow(context.Message);
+        
+        var message = context.Message.Data;
         if (message.ChangeType != PopugChangedTypes.Created)
             return;
         

--- a/PopugJira/PopugJira.Tracker/Models/PopugTask.cs
+++ b/PopugJira/PopugJira.Tracker/Models/PopugTask.cs
@@ -5,6 +5,7 @@ public class PopugTask
     public required Guid Id { get; init; }
     public required Guid Assignee { get; set; }
     public required string Description { get; set; }
+    public string? JiraId { get; set; }
     public required string Status { get; set; }
 }
 

--- a/PopugJira/PopugJira.Tracker/Services/EventSender.cs
+++ b/PopugJira/PopugJira.Tracker/Services/EventSender.cs
@@ -1,25 +1,48 @@
-﻿using MassTransit;
+﻿using EventSchemaRegistry;
+using MassTransit;
 using PopugJira.Tracker.Contracts;
 using PopugJira.Tracker.Models;
 
 namespace PopugJira.Tracker.Services;
 
-public class EventSender(ITopicProducer<TaskOperationPerformed> taskOperationProducer, 
-    ITopicProducer<TaskChanged> taskChangedProducer)
+public class EventSender(
+    ITopicProducer<KafkaEvent<Task_Added_V1>> taskAddedProducer, 
+    ITopicProducer<KafkaEvent<Task_Assigned_V1>> taskAssignedProducer, 
+    ITopicProducer<KafkaEvent<Task_Completed_V1>> taskCompletedProducer, 
+    ITopicProducer<KafkaEvent<Task_Changed_V1>> taskChangedProducer)
 {
+    private const string Producer = "tracker";
+
     public async Task TaskCreated(PopugTask task)
     {
-        await taskChangedProducer.Produce(new TaskChanged(task.Id, task.Description, task.Assignee, task.Status, TaskChangedTypes.Created));
-        await taskOperationProducer.Produce(new TaskOperationPerformed(task.Id, TaskOperationTypes.AddedNew, task.Assignee));
+        var messageCud = new KafkaEvent<Task_Changed_V1>(
+            new Task_Changed_V1(task.Id, task.Description, task.Assignee, task.Status, TaskChangedTypes.Created),
+            Producer);
+        SchemeValidator.ValidateOrThrow(messageCud);
+        await taskChangedProducer.Produce(messageCud);
+        
+        var messageCudV2 = new KafkaEvent<Task_Changed_V2>(
+            new Task_Changed_V2(task.Id, task.Description, task.JiraId, task.Assignee, task.Status, TaskChangedTypes.Created),
+            Producer);
+        SchemeValidator.ValidateOrThrow(messageCudV2);
+        await taskChangedProducer.Produce(messageCudV2);
+
+        var messageBusiness = new KafkaEvent<Task_Added_V1>(new Task_Added_V1(task.Id, task.Assignee), Producer);
+        SchemeValidator.ValidateOrThrow(messageBusiness);
+        await taskAddedProducer.Produce(messageBusiness);
     }
 
     public async Task TaskAssigned(PopugTask task)
     {
-        await taskOperationProducer.Produce(new TaskOperationPerformed(task.Id, TaskOperationTypes.Assigned, task.Assignee));
+        var message = new KafkaEvent<Task_Assigned_V1>(new Task_Assigned_V1(task.Id, task.Assignee), Producer);
+        SchemeValidator.ValidateOrThrow(message);
+        await taskAssignedProducer.Produce(message);   
     }
     
     public async Task TaskCompleted(PopugTask task)
     {
-        await taskOperationProducer.Produce(new TaskOperationPerformed(task.Id, TaskOperationTypes.Completed, task.Assignee));
+        var message = new KafkaEvent<Task_Completed_V1>(new Task_Completed_V1(task.Id, task.Assignee), Producer);
+        SchemeValidator.ValidateOrThrow(message);
+        await taskCompletedProducer.Produce(message);    
     }
 }

--- a/PopugJira/PopugJira.Tracker/ViewModels/Tasks/AddTaskDto.cs
+++ b/PopugJira/PopugJira.Tracker/ViewModels/Tasks/AddTaskDto.cs
@@ -1,3 +1,3 @@
 ﻿namespace PopugJira.Tracker.ViewModels.Tasks;
 
-public record AddTaskDto(string Description);
+public record AddTaskDto(string Description, string? JiraId);


### PR DESCRIPTION
и снова только самое важное в ПР;)

по поводу миграции на новую логику названий тасков:
1. В сервисах потребителях (аккаунтинг, аналитика) добавляем консьюмер для в2 событий
2. Катим их
3. Убедившись, что все кому надо перешли, добавляем продюсер в2 в трекер, убираем в1 продюсер
4. катим трекер